### PR TITLE
Fix missing import in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@ Usage:
 The library is very simple to use: just import it and in case, wait for input.
 
 ```
+import logging
+
 from usb_scanner.scanner import barcode_reader
+
 if __name__ == '__main__':
     try:
         while True:


### PR DESCRIPTION
I tried the example code mentioned in README and got the following error:
```
Traceback (most recent call last):
  File "example.py", line 12, in <module>
    logging.error(err)
NameError: name 'logging' is not defined
```
It seems like `import logging` is missing